### PR TITLE
Replace slashes in branch name for docker hub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,6 +86,9 @@ steps:
   when:
     event:
     - push
+    branch:
+      exclude:
+      - dependabot/*
 
 - name: docker push autotag + latest
   image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -78,7 +78,7 @@ steps:
   settings:
     repo: liquidinvestigations/hoover-snoop2
     # https://0-8-0.docs.drone.io/substitution/
-    tags: ${DRONE_COMMIT_BRANCH/\//-}
+    tags: ${DRONE_COMMIT_BRANCH}
     username:
       from_secret: docker_username
     password:
@@ -88,7 +88,7 @@ steps:
     - push
     branch:
       exclude:
-      - dependabot/*
+      - dependabot/**
 
 - name: docker push autotag + latest
   image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,15 +77,13 @@ steps:
   image: plugins/docker
   settings:
     repo: liquidinvestigations/hoover-snoop2
-    tags: ${DRONE_COMMIT_BRANCH}
+    # https://0-8-0.docs.drone.io/substitution/
+    tags: ${DRONE_COMMIT_BRANCH/\//-}
     username:
       from_secret: docker_username
     password:
       from_secret: docker_password
   when:
-    branch:
-      excludes:
-        - dependabot/*
     event:
     - push
 


### PR DESCRIPTION
CI fails when a dependabot branch with `/` in its name is pushed directly to docker hub: https://jenkins.liquiddemo.org/liquidinvestigations/hoover-snoop2/449