### PR TITLE
Automate index creation

### DIFF
--- a/snoop/data/management/commands/initcollection.py
+++ b/snoop/data/management/commands/initcollection.py
@@ -1,6 +1,5 @@
 from django.core.management.base import BaseCommand
 
-from ... import indexing, models
 from ...logs import logging_for_management_command
 
 

--- a/snoop/data/management/commands/initcollection.py
+++ b/snoop/data/management/commands/initcollection.py
@@ -9,8 +9,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         logging_for_management_command(options['verbosity'])
-
-        if not models.Directory.root():
-            models.Directory.objects.create()
-
-        indexing.create_index()
+        print("initcollection is now a no-op")

--- a/snoop/data/tasks.py
+++ b/snoop/data/tasks.py
@@ -415,6 +415,11 @@ def dispatch_walk_tasks():
     from .filesystem import walk
     root = models.Directory.root()
     if not root:
+        try:
+            indexing.create_index()
+        except RuntimeError:
+            # already created?
+            pass
         root = models.Directory.objects.create()
     walk.laterz(root.pk)
 

--- a/snoop/data/tasks.py
+++ b/snoop/data/tasks.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from . import celery
 from . import models
+from . import indexing
 from ..profiler import profile
 from .utils import run_once
 from requests.exceptions import ConnectionError

--- a/testsuite/docker-compose.override.travis-snoop2.yml
+++ b/testsuite/docker-compose.override.travis-snoop2.yml
@@ -6,6 +6,7 @@ services:
     environment:
       POSTGRES_USER: snoop
       POSTGRES_DATABASE: snoop
+      POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - ./volumes/snoop-pg/data:/var/lib/postgresql/data
 


### PR DESCRIPTION
Snoop 0.5.0 broke the node testsuite (https://github.com/liquidinvestigations/node/commit/2f0b25aa98825417974d133bc362a913985bcda7). I suspect it's because workers start processing and push digests to the index before `initcollection` is called.