### PR TITLE
Urlprefix, admin sites

### DIFF
--- a/snoop/data/admin.py
+++ b/snoop/data/admin.py
@@ -14,14 +14,9 @@ from django.shortcuts import render
 from django.db.models import Sum, Count, Avg, F
 from django.db import connections
 from django.contrib.humanize.templatetags.humanize import naturaltime
-from django.http import HttpResponseRedirect
 from . import models
 from . import tasks
 from . import collections
-
-
-def redirect_to_admin(request):
-    return HttpResponseRedirect('/admin/')
 
 
 def blob_link(blob_pk):

--- a/snoop/data/admin.py
+++ b/snoop/data/admin.py
@@ -3,10 +3,7 @@ from datetime import timedelta
 from collections import defaultdict
 from django.urls import reverse
 from django.contrib import admin
-from django.contrib.auth import models as auth_models
-from django.contrib.auth import admin as auth_admin
-from django.contrib.admin.views.decorators import staff_member_required
-from django.utils.decorators import method_decorator
+from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils import timezone
 from django.urls import path
@@ -20,7 +17,7 @@ from . import collections
 
 
 def blob_link(blob_pk):
-    url = reverse('admin:data_blob_change', args=[blob_pk])
+    url = reverse(f'{collections.current().name}:data_blob_change', args=[blob_pk])
     return mark_safe(f'<a href="{url}">{blob_pk[:10]}...{blob_pk[-4:]}</a>')
 
 
@@ -108,11 +105,61 @@ def get_stats():
     }
 
 
-class DirectoryAdmin(admin.ModelAdmin):
+class MultiDBModelAdmin(admin.ModelAdmin):
+    # A handy constant for the name of the alternate database.
+    def __init__(self, *args, **kwargs):
+        self.collection = collections.current()
+        self.using = self.collection.db_name
+        return super().__init__(*args, **kwargs)
+
+    def add_view(self, *args, **kwargs):
+        with self.collection.set_current():
+            return super().add_view(*args, **kwargs)
+
+    def change_view(self, *args, **kwargs):
+        with self.collection.set_current():
+            return super().change_view(*args, **kwargs)
+
+    def changelist_view(self, *args, **kwargs):
+        with self.collection.set_current():
+            return super().changelist_view(*args, **kwargs)
+
+    def delete_view(self, *args, **kwargs):
+        with self.collection.set_current():
+            return super().delete_view(*args, **kwargs)
+
+    def history_view(self, *args, **kwargs):
+        with self.collection.set_current():
+            return super().history_view(*args, **kwargs)
+
+    def save_model(self, request, obj, form, change):
+        # Tell Django to save objects to the 'other' database.
+        obj.save(using=self.using)
+
+    def delete_model(self, request, obj):
+        # Tell Django to delete objects from the 'other' database
+        obj.delete(using=self.using)
+
+    def get_queryset(self, request):
+        # Tell Django to look for objects on the 'other' database.
+        return super().get_queryset(request).using(self.using)
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # Tell Django to populate ForeignKey widgets using a query
+        # on the 'other' database.
+        return super().formfield_for_foreignkey(db_field, request, using=self.using, **kwargs)
+
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        # Tell Django to populate ManyToMany widgets using a query
+        # on the 'other' database.
+        return super().formfield_for_manytomany(db_field, request, using=self.using, **kwargs)
+
+
+class DirectoryAdmin(MultiDBModelAdmin):
     raw_id_fields = ['parent_directory', 'container_file']
 
 
-class FileAdmin(admin.ModelAdmin):
+class FileAdmin(MultiDBModelAdmin):
     raw_id_fields = ['parent_directory', 'original', 'blob']
     list_display = ['__str__', 'size', 'mime_type',
                     'original_blob_link', 'blob_link']
@@ -137,17 +184,19 @@ class FileAdmin(admin.ModelAdmin):
         return obj.original.mime_type
 
     def original_blob_link(self, obj):
-        return blob_link(obj.original.pk)
+        with self.collection.set_current():
+            return blob_link(obj.original.pk)
 
     original_blob_link.short_description = 'original blob'
 
     def blob_link(self, obj):
-        return blob_link(obj.blob.pk)
+        with self.collection.set_current():
+            return blob_link(obj.blob.pk)
 
     blob_link.short_description = 'blob'
 
 
-class BlobAdmin(admin.ModelAdmin):
+class BlobAdmin(MultiDBModelAdmin):
     list_display = ['__str__', 'mime_type', 'mime_encoding', 'created']
     list_filter = ['mime_type']
     search_fields = ['sha3_256', 'sha256', 'sha1', 'md5',
@@ -157,20 +206,21 @@ class BlobAdmin(admin.ModelAdmin):
     change_form_template = 'snoop/admin_blob_change_form.html'
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
-        extra_context = extra_context or {}
+        with self.collection.set_current():
+            extra_context = extra_context or {}
 
-        if object_id:
-            blob = models.Blob.objects.get(pk=object_id)
-            if blob.mime_type in ['text/plain', 'application/json']:
-                extra_context['preview'] = True
+            if object_id:
+                blob = models.Blob.objects.get(pk=object_id)
+                if blob.mime_type in ['text/plain', 'application/json']:
+                    extra_context['preview'] = True
 
-                if request.GET.get('preview'):
-                    content = self.get_preview_content(blob)
-                    extra_context['preview_content'] = content
+                    if request.GET.get('preview'):
+                        content = self.get_preview_content(blob)
+                        extra_context['preview_content'] = content
 
-        return super().change_view(
-            request, object_id, form_url, extra_context=extra_context,
-        )
+            return super().change_view(
+                request, object_id, form_url, extra_context=extra_context,
+            )
 
     def created(self, obj):
         return naturaltime(obj.date_created)
@@ -188,7 +238,7 @@ class BlobAdmin(admin.ModelAdmin):
             return ''
 
 
-class TaskAdmin(admin.ModelAdmin):
+class TaskAdmin(MultiDBModelAdmin):
     raw_id_fields = ['blob_arg', 'result']
     list_display = ['pk', 'func', 'args', 'created', 'finished',
                     'status', 'details']
@@ -207,15 +257,16 @@ class TaskAdmin(admin.ModelAdmin):
     }
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
-        extra_context = extra_context or {}
+        with self.collection.set_current():
+            extra_context = extra_context or {}
 
-        if object_id:
-            obj = models.Task.objects.get(pk=object_id)
-            extra_context['task_dependency_links'] = self.dependency_links(obj)
+            if object_id:
+                obj = models.Task.objects.get(pk=object_id)
+                extra_context['task_dependency_links'] = self.dependency_links(obj)
 
-        return super().change_view(
-            request, object_id, form_url, extra_context=extra_context,
-        )
+            return super().change_view(
+                request, object_id, form_url, extra_context=extra_context,
+            )
 
     def created(self, obj):
         return naturaltime(obj.date_created)
@@ -230,7 +281,7 @@ class TaskAdmin(admin.ModelAdmin):
     def dependency_links(self, obj):
         def link(dep):
             task = dep.prev
-            url = reverse('admin:data_task_change', args=[task.pk])
+            url = reverse(f'{self.collection.name}:data_task_change', args=[task.pk])
             style = self.LINK_STYLE[task.status]
             return f'<a href="{url}" style="{style}">{dep.name}</a>'
 
@@ -248,56 +299,90 @@ class TaskAdmin(admin.ModelAdmin):
         self.message_user(request, f"requeued {queryset.count()} tasks")
 
 
-class TaskDependencyAdmin(admin.ModelAdmin):
+class TaskDependencyAdmin(MultiDBModelAdmin):
     raw_id_fields = ['prev', 'next']
 
 
-class DigestAdmin(admin.ModelAdmin):
+class DigestAdmin(MultiDBModelAdmin):
     raw_id_fields = ['blob', 'result']
-    list_display = ['pk', 'blob__mime_type', 'blob_link',
-                    'result_link', 'date_modified']
-    list_filter = ['blob__mime_type']
+    list_display = ['pk', 'blob__mime_type', 'blob_link', 'result_link', 'date_modified']
     search_fields = ['pk', 'blob__pk', 'result__pk']
+    # TODO subclass django.contrib.admin.filters.AllValuesFieldListFilter.choices()
+    # to set the current collection
+    # list_filter = ['blob__mime_type']
 
     def blob__mime_type(self, obj):
-        return obj.blob.mime_type
+        with self.collection.set_current():
+            return obj.blob.mime_type
 
     def blob_link(self, obj):
-        return blob_link(obj.blob.pk)
+        with self.collection.set_current():
+            return blob_link(obj.blob.pk)
 
     def result_link(self, obj):
-        return blob_link(obj.result.pk)
+        with self.collection.set_current():
+            return blob_link(obj.result.pk)
 
 
-class SnoopAminSite(admin.AdminSite):
-
+class SnoopAdminSite(admin.AdminSite):
     site_header = "Snoop Mk2"
+    index_template = 'snoop/admin_index_default.html'
 
+    def each_context(self, request):
+        context = super().each_context(request)
+        context['collection_links'] = get_admin_links()
+        return context
+
+
+class CollectionAdminSite(SnoopAdminSite):
     index_template = 'snoop/admin_index.html'
+
+    def __init__(self, *args, **kwargs):
+        self.collection = collections.current()
+        return super().__init__(*args, **kwargs)
 
     def get_urls(self):
         return super().get_urls() + [
             path('stats', self.stats),
         ]
 
-    @method_decorator(staff_member_required)
+    def admin_view(self, *args, **kwargs):
+        with self.collection.set_current():
+            return super().admin_view(*args, **kwargs)
+
     def stats(self, request):
-        context = dict(self.each_context(request))
-        context.update(get_stats())
-        return render(request, 'snoop/admin_stats.html', context)
+        with self.collection.set_current():
+            context = dict(self.each_context(request))
+            context.update(get_stats())
+            return render(request, 'snoop/admin_stats.html', context)
 
 
-site = SnoopAminSite(name='snoopadmin')
+def make_collection_admin_site(collection):
+    with collection.set_current():
+        site = CollectionAdminSite(name=collection.name)
+        site.site_header = f'collection "{collection.name}"'
+        site.index_title = "task stats, logs, results"
+
+        site.register(models.Directory, DirectoryAdmin)
+        site.register(models.File, FileAdmin)
+        site.register(models.Blob, BlobAdmin)
+        site.register(models.Task, TaskAdmin)
+        site.register(models.TaskDependency, TaskDependencyAdmin)
+        site.register(models.Digest, DigestAdmin)
+        site.register(models.OcrSource, MultiDBModelAdmin)
+        site.register(models.OcrDocument, MultiDBModelAdmin)
+        return site
 
 
-site.register(auth_models.User, auth_admin.UserAdmin)
-site.register(auth_models.Group, auth_admin.GroupAdmin)
+def get_admin_links():
+    global sites
+    for name in sorted(sites.keys()):
+        yield name, f'/{settings.URL_PREFIX}admin/{name}/'
 
-site.register(models.Directory, DirectoryAdmin)
-site.register(models.File, FileAdmin)
-site.register(models.Blob, BlobAdmin)
-site.register(models.Task, TaskAdmin)
-site.register(models.TaskDependency, TaskDependencyAdmin)
-site.register(models.Digest, DigestAdmin)
-site.register(models.OcrSource)
-site.register(models.OcrDocument)
+
+DEFAULT_ADMIN_NAME = '_default'
+sites = {}
+for collection in collections.ALL.values():
+    sites[collection.name] = make_collection_admin_site(collection)
+
+sites[DEFAULT_ADMIN_NAME] = admin.site

--- a/snoop/data/apps.py
+++ b/snoop/data/apps.py
@@ -1,5 +1,10 @@
 from django.apps import AppConfig
+from django.contrib.admin.apps import AdminConfig
 
 
 class DataConfig(AppConfig):
     name = 'data'
+
+
+class AdminConfig(AdminConfig):
+    default_site = 'snoop.data.admin.SnoopAdminSite'

--- a/snoop/data/auto_login.py
+++ b/snoop/data/auto_login.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.models import User
+
+
+class Middleware():
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        root, created = User.objects.get_or_create(username='root')
+        if created or not root.is_superuser:
+            root.is_superuser = True
+            root.is_admin = True
+            root.is_active = True
+            root.set_password('root')
+            root.save()
+
+        request.user = root
+        return self.get_response(request)

--- a/snoop/data/collections.py
+++ b/snoop/data/collections.py
@@ -57,7 +57,8 @@ class Collection:
 
     @contextmanager
     def set_current(self):
-        assert getattr(threadlocal, 'collection', None) is None, \
+        old = getattr(threadlocal, 'collection', None)
+        assert old in (None, self), \
             "There is already a current collection"
         try:
             threadlocal.collection = self
@@ -67,7 +68,7 @@ class Collection:
             logger.debug("WITH collectio = %s END", self)
             assert threadlocal.collection is self, \
                 "Current collection has changed!"
-            threadlocal.collection = None
+            threadlocal.collection = old
 
 
 ALL = {}

--- a/snoop/data/templates/snoop/admin_index.html
+++ b/snoop/data/templates/snoop/admin_index.html
@@ -1,18 +1,12 @@
-{% extends "admin/index.html" %}
+{% extends "snoop/admin_index_default.html" %}
 
 {% block content %}
 
-  {{ block.super }}
-
   <div id="snoop-links">
-    <a href="stats">Task stats</a>
+    <p>
+    Visit <a href="stats">TASK STATS</a> for this collection.
+    </p>
   </div>
 
-
-  <script>
-    document.querySelector('#content-main').append(
-      document.querySelector('#snoop-links')
-    );
-  </script>
-
+  {{ block.super }}
 {% endblock %}

--- a/snoop/data/templates/snoop/admin_index_default.html
+++ b/snoop/data/templates/snoop/admin_index_default.html
@@ -1,0 +1,28 @@
+{% extends "admin/index.html" %}
+
+{% block content %}
+
+  {{ block.super }}
+
+  <div id="snoop-collection-links">
+    <h2>Admin Site Index</h2>
+    <p>
+    Navigate to other admin sites from here.
+    <ol>
+    {% for name, link in collection_links %}
+      <li>
+        <a href={{link}}><b>{{name}}</b></a>
+      </li>
+    {% endfor %}
+    </ol>
+    </p>
+  </div>
+
+  <script>
+    document.querySelector('#content-main').append(
+      document.querySelector('#snoop-collection-links')
+    );
+  </script>
+
+
+{% endblock %}

--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -15,7 +15,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', default_secret_key)
 ALLOWED_HOSTS = [os.environ.get('SNOOP_HOSTNAME', '*')]
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
+    'snoop.data.apps.AdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -29,7 +29,10 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'snoop.data.auto_login.Middleware',
+
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -96,9 +99,6 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-STATIC_URL = '/static/'
-STATIC_ROOT = str(base_dir / 'static')
-
 SNOOP_COLLECTIONS_ELASTICSEARCH_URL = os.environ.get('SNOOP_ES_URL', 'http://localhost:9200')
 
 SNOOP_BLOB_STORAGE = str(base_dir / 'blobs')
@@ -118,7 +118,12 @@ CHILD_QUEUE_LIMIT = 100
 DISPATCH_QUEUE_LIMIT = 5000
 
 # url prefix for all the views, for example "snoop/"
-URL_PREFIX = os.getenv('SNOOP_URL_PREFIX')
+URL_PREFIX = os.getenv('SNOOP_URL_PREFIX', '')
+if URL_PREFIX:
+    assert URL_PREFIX.endswith('/') and not URL_PREFIX.startswith('/')
+
+STATIC_URL = '/' + URL_PREFIX + 'static/'
+STATIC_ROOT = str(base_dir / 'static')
 
 
 def bool_env(value):

--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -12,10 +12,7 @@ DEBUG = os.environ.get('DEBUG', '').lower() in ['on', 'true']
 default_secret_key = 'placeholder key for development'
 SECRET_KEY = os.environ.get('SECRET_KEY', default_secret_key)
 
-ALLOWED_HOSTS = []
-_hostname = os.environ.get('SNOOP_HOSTNAME')
-if _hostname:
-    ALLOWED_HOSTS.append(_hostname)
+ALLOWED_HOSTS = [os.environ.get('SNOOP_HOSTNAME', '*')]
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -120,6 +120,9 @@ CHILD_QUEUE_LIMIT = 100
 # will be retried by sync every minute.
 DISPATCH_QUEUE_LIMIT = 5000
 
+# url prefix for all the views, for example "snoop/"
+URL_PREFIX = os.getenv('SNOOP_URL_PREFIX')
+
 
 def bool_env(value):
     return (value or '').lower() in ['on', 'true']

--- a/snoop/urls.py
+++ b/snoop/urls.py
@@ -1,11 +1,17 @@
 from django.urls import path, include
+from django.conf import settings
 
 from snoop import views
 from snoop.data import admin
 
-urlpatterns = [
+base_urlpatterns = [
     path('_health', views.health),
     path('', admin.redirect_to_admin),
     path('admin/', admin.site.urls),
     path('collections/', include('snoop.data.urls')),
 ]
+
+if settings.URL_PREFIX:
+    urlpatterns = [path(settings.URL_PREFIX, include(base_urlpatterns)]
+else:
+    urlpatterns = base_urlpatterns

--- a/snoop/urls.py
+++ b/snoop/urls.py
@@ -7,19 +7,14 @@ from snoop.data import admin
 
 
 def redirect_to_admin(request):
-    if settings.URL_PREFIX:
-        url = '/' + settings.URL_PREFIX + 'admin/'
-    else:
-        url = '/admin/'
-    return HttpResponseRedirect(url)
+    return HttpResponseRedirect(f'/{settings.URL_PREFIX}admin/_default/')
 
 
 base_urlpatterns = [
     path('_health', views.health),
     path('', redirect_to_admin),
-    path('admin/', admin.site.urls),
     path('collections/', include('snoop.data.urls')),
-]
+] + [path(f'admin/{k}/', v.urls) for k, v in admin.sites.items()]
 
 if settings.URL_PREFIX:
     urlpatterns = [path(settings.URL_PREFIX, include(base_urlpatterns))]

--- a/snoop/urls.py
+++ b/snoop/urls.py
@@ -1,12 +1,22 @@
 from django.urls import path, include
+from django.http import HttpResponseRedirect
 from django.conf import settings
 
 from snoop import views
 from snoop.data import admin
 
+
+def redirect_to_admin(request):
+    if settings.URL_PREFIX:
+        url = '/' + settings.URL_PREFIX + 'admin/'
+    else:
+        url = '/admin/'
+    return HttpResponseRedirect(url)
+
+
 base_urlpatterns = [
     path('_health', views.health),
-    path('', admin.redirect_to_admin),
+    path('', redirect_to_admin),
     path('admin/', admin.site.urls),
     path('collections/', include('snoop.data.urls')),
 ]

--- a/snoop/urls.py
+++ b/snoop/urls.py
@@ -12,6 +12,6 @@ base_urlpatterns = [
 ]
 
 if settings.URL_PREFIX:
-    urlpatterns = [path(settings.URL_PREFIX, include(base_urlpatterns)]
+    urlpatterns = [path(settings.URL_PREFIX, include(base_urlpatterns))]
 else:
     urlpatterns = base_urlpatterns


### PR DESCRIPTION
Added auto-login and configurable url prefix for hosting behind a firewalled reverse proxy. Fixed the admin UI to show all info for all collections, implemented as one site per collection.