### PR TITLE
Add view and API entry for File model

### DIFF
--- a/snoop/data/urls.py
+++ b/snoop/data/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path('<collection>/_directory_<int:pk>/json', views.directory),
+    path('<collection>/_file_<int:pk>/json', views.file_view),
     path('<collection>/<hash>/json', views.document),
     path('<collection>/<hash>/raw/<filename>', views.document_download),
     path('<collection>/<hash>/ocr/<ocrname>/', views.document_ocr),

--- a/snoop/data/views.py
+++ b/snoop/data/views.py
@@ -62,6 +62,12 @@ def feed(request):
 
 
 @collection_view
+def file_view(request, pk):
+    file_query = get_object_or_404(models.File.objects, pk=pk)
+    return JsonResponse(digests.get_file_data(file_query))
+
+
+@collection_view
 def directory(request, pk):
     directory = get_object_or_404(models.Directory.objects, pk=pk)
     return JsonResponse(digests.get_directory_data(directory))


### PR DESCRIPTION
I added a view for models.File. It is similar to the Directory and Digest views.
Now, every file can be accessed with a unique id in the format "\_file\_\<pk\>", instead of a sha3 of its contents.

Solves #159
