### PR TITLE
Map missing filetypes

### DIFF
--- a/snoop/data/_file_types.py
+++ b/snoop/data/_file_types.py
@@ -5,13 +5,9 @@ FILE_TYPES = {
     'text/html': 'html',
     'application/x-hush-pgp-encrypted-html-body': 'html',
     'application/xhtml+xml': 'html',
-    'application/xml': 'html',
-    'text/xml': 'html',
     'message/x-emlx': 'email',
     'message/rfc822': 'email',
     'application/vnd.ms-outlook': 'email',
-    'application/vnd.ms-office': 'email',
-    'application/CDFV2': 'email',
 
     'application/x-hoover-pst': 'email-archive',
     'application/mbox': 'email-archive',

--- a/snoop/data/_file_types.py
+++ b/snoop/data/_file_types.py
@@ -4,11 +4,17 @@ FILE_TYPES = {
     'text/plain': 'text',
     'text/html': 'html',
     'application/x-hush-pgp-encrypted-html-body': 'html',
+    'application/xhtml+xml': 'html',
+    'application/xml': 'html',
+    'text/xml': 'html',
     'message/x-emlx': 'email',
     'message/rfc822': 'email',
     'application/vnd.ms-outlook': 'email',
+    'application/vnd.ms-office': 'email',
+    'application/CDFV2': 'email',
 
     'application/x-hoover-pst': 'email-archive',
+    'application/mbox': 'email-archive',
 
     'application/msword': 'doc',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'doc',


### PR DESCRIPTION
closes CRJI/EIC#667.

Related to #425.

I mapped the missing filetypes. For `application/vnd.ms-office` and `application/CDFV2` I couldn't really find any information on what they actually are but they are mapped to `email` for now.

The only logic that is affected by the mapped type seems to be here:
https://github.com/liquidinvestigations/hoover-snoop2/blob/99b55e5c69a1bd522136effedb886f8d2bf667b8/snoop/data/digests.py#L445-L458

Do we want any changes there? 