### PR TITLE
refactor archive_walk using os.scandir

### DIFF
--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -175,7 +175,6 @@ def unarchive(blob):
     documents that embed images).
     """
     with collections.current().tmp_dir / str(blob) as temp_dir:
-        print(temp_dir)
         if blob.mime_type in SEVENZIP_MIME_TYPES:
             call_7z(blob.path(), temp_dir)
         elif blob.mime_type in READPST_MIME_TYPES:

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -184,10 +184,7 @@ def unarchive(blob):
         elif blob.mime_type in PDF_KNOWN_TYPES:
             unpack_pdf(blob.path(), temp_dir)
 
-        listing = sorted(
-            list(archive_walk(Path(temp_dir))),
-            key=lambda c: c['name'],
-        )
+        listing = archive_walk(Path(temp_dir))
 
     check_recursion(listing, blob.pk)
 
@@ -202,21 +199,22 @@ def archive_walk(path):
         for d in dirs:
             dir_info = {
                 'type' : 'directory',
-                'name' :  d,
+                'name' :  os.path.relpath(d),
                 'children' : [],
             }
             children.append(dir_info)
         for f in files:
             file_info = {
                 'type' : 'file',
-                'name' : f,
+                'name' : os.path.relpath(f),
                 'blob_pk' : models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
             }
             children.append(file_info)
         root_info = {
             'type' : 'directory',
-            'name' : root,
+            'name' : os.path.relpath(root),
             'children' : children,
         }
         res.append(root_info)
+    print(res)
     return res

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -198,22 +198,22 @@ def archive_walk(path):
         children = []
         for d in dirs:
             dir_info = {
-                'type' : 'directory',
-                'name' :  os.path.relpath(d),
-                'children' : [],
+                'type': 'directory',
+                'name': os.path.relpath(d),
+                'children': [],
             }
             children.append(dir_info)
         for f in files:
             file_info = {
-                'type' : 'file',
-                'name' : os.path.relpath(f),
-                'blob_pk' : models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
+                'type': 'file',
+                'name': os.path.relpath(f),
+                'blob_pk': models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
             }
             children.append(file_info)
         root_info = {
-            'type' : 'directory',
-            'name' : os.path.relpath(root),
-            'children' : children,
+            'type': 'directory',
+            'name': os.path.relpath(root),
+            'children': children,
         }
         res.append(root_info)
     print(res)

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -2,12 +2,12 @@
 """
 
 import subprocess
-import tempfile
 from pathlib import Path
 from hashlib import sha1
 import re
 from ..tasks import snoop_task, SnoopTaskBroken, returns_json_blob
 from .. import models
+from .. import collections
 import os
 
 SEVENZIP_MIME_TYPES = {
@@ -50,7 +50,8 @@ def is_archive(mime_type):
 
 def call_readpst(pst_path, output_dir):
     """Helper function that calls a `readpst` process."""
-
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
     try:
         subprocess.check_output([
             'readpst',
@@ -173,7 +174,8 @@ def unarchive(blob):
     Runs on archives, email archives and any other file types that can contain another file (such as
     documents that embed images).
     """
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with collections.current().tmp_dir / str(blob) as temp_dir:
+        print(temp_dir)
         if blob.mime_type in SEVENZIP_MIME_TYPES:
             call_7z(blob.path(), temp_dir)
         elif blob.mime_type in READPST_MIME_TYPES:
@@ -210,7 +212,7 @@ def archive_walk(path):
 
 
 def create_blobs(dirlisting):
-    """Create blobs for files in archive listing created by archive_walk"""
+    """Create blobs for files in archive listing created by [snoop.data.analyzers.archive_walk."""
 
     for entry in dirlisting:
         if entry['type'] == 'file':

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -192,6 +192,8 @@ def unarchive(blob):
 
 
 def archive_walk(path):
+    """Generates simple dicts with archive listing for the archive. """
+
     for entry in os.scandir(path):
         print(entry.path)
         if entry.is_dir(follow_symlinks=False):
@@ -209,6 +211,8 @@ def archive_walk(path):
 
 
 def create_blobs(dirlisting):
+    """Create blobs for files in archive listing created by archive_walk"""
+
     for entry in dirlisting:
         if entry['type'] == 'file':
             print(entry['path'])

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -187,7 +187,6 @@ def unarchive(blob):
         create_blobs(listing)
 
     check_recursion(listing, blob.pk)
-    print(listing)
 
     return listing
 
@@ -196,7 +195,6 @@ def archive_walk(path):
     """Generates simple dicts with archive listing for the archive. """
 
     for entry in os.scandir(path):
-        print(entry.path)
         if entry.is_dir(follow_symlinks=False):
             yield {
                 'type': 'directory',
@@ -216,7 +214,6 @@ def create_blobs(dirlisting):
 
     for entry in dirlisting:
         if entry['type'] == 'file':
-            print(entry['path'])
             path = Path(entry['path'])
             entry['blob_pk'] = models.Blob.create_from_file(path).pk
             del entry['path']

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -184,7 +184,11 @@ def unarchive(blob):
         elif blob.mime_type in PDF_KNOWN_TYPES:
             unpack_pdf(blob.path(), temp_dir)
 
-        listing = archive_walk(Path(temp_dir))
+<<<<<<< Updated upstream
+=======
+        print()
+>>>>>>> Stashed changes
+        listing = archive_walk(temp_dir)
 
     check_recursion(listing, blob.pk)
 
@@ -193,27 +197,54 @@ def unarchive(blob):
 
 def archive_walk(path):
     """Generates simple dicts with archive listing for the archive. """
+    print(path)
+    walk_iter = os.walk(path, topdown=True)
+    print(list(next(walk_iter)))
     res = []
-    for root, dirs, files in os.walk(path, topdown=True):
+    for root, dirs, files in walk_iter:
+        print("Root:")
+        print(root)
+        print("Dirs:")
+        print(dirs)
+        print("Files:")
+        print(files)
         children = []
         for d in dirs:
             dir_info = {
+<<<<<<< Updated upstream
                 'type': 'directory',
-                'name': os.path.relpath(d),
+                'name': d,
                 'children': [],
+=======
+                'type' : 'directory',
+                'name' :  d,
+                'children' : [],
+>>>>>>> Stashed changes
             }
             children.append(dir_info)
         for f in files:
             file_info = {
+<<<<<<< Updated upstream
                 'type': 'file',
-                'name': os.path.relpath(f),
+                'name': f,
                 'blob_pk': models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
             }
             children.append(file_info)
         root_info = {
             'type': 'directory',
-            'name': os.path.relpath(root),
+            'name': '/'.join(list(Path(root).parts[3:])),
             'children': children,
+=======
+                'type' : 'file',
+                'name' : f,
+                'blob_pk' : models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
+            }
+            children.append(file_info)
+        root_info = {
+            'type' : 'directory',
+            'name' : '/'.join(list(Path(root).parts[3:])),
+            'children' : children,
+>>>>>>> Stashed changes
         }
         res.append(root_info)
     print(res)

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -9,7 +9,9 @@ import re
 from ..tasks import snoop_task, SnoopTaskBroken, returns_json_blob
 from .. import models
 import os
-
+import pprint
+from timeit import default_timer as timer
+import sys 
 
 SEVENZIP_MIME_TYPES = {
     'application/x-7z-compressed',
@@ -184,68 +186,144 @@ def unarchive(blob):
         elif blob.mime_type in PDF_MIME_TYPES:
             unpack_pdf(blob.path(), temp_dir)
 
-<<<<<<< Updated upstream
-=======
-        print()
->>>>>>> Stashed changes
-        listing = archive_walk(temp_dir)
+        old_listing = list(old_archive_walk(Path(temp_dir)))
+        listing = list(archive_walk(Path(temp_dir)))
+        create_blobs(listing)
+        print('Listing:------------------')
+        print(listing)
+        print('Old Listing:------------------')
+        print(old_listing)
+        assert listing == old_listing
+
+
+    print('Size:')
+    print(sys.getsizeof(listing)/20**2)
 
     check_recursion(listing, blob.pk)
 
     return listing
 
 
-def archive_walk(path):
+# def archive_walk(path):
+#     """Generates simple dicts with archive listing for the archive. """
+#     print(path)
+#     walk_iter = os.walk(path, topdown=True)
+#     print(list(next(walk_iter)))
+#     res = []
+#     (root, dirs, files) = next(walk_iter)
+#     children = []
+#     for f in files:
+#         file_info = {
+#             'type': 'file',
+#             'name': f,
+#             'blob_pk': models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
+#         }
+#         children.append(file_info)
+#     root_info = {
+#         'type': 'directory',
+#         'parent': '',
+#         'name': os.path.basename(root),
+#         'children': children
+#     }
+#     res.append(root_info)
+#     for root, dirs, files in walk_iter:
+#         print("Root:")
+#         print(root)
+#         print("Root2:")
+#         print(root)
+#         print("Dirs:")
+#         print(dirs)
+#         print("Files:")
+#         print(files)
+#         children = []
+#         # for d in dirs:
+#         #     dir_info = {
+#         #         'type': 'directory',
+#         #         'name': d,
+#         #         'children': [],
+#         #     }
+#         #     children.append(dir_info)
+#         for f in files:
+#             file_info = {
+#                 'type': 'file',
+#                 'name': f,
+#                 'blob_pk': models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
+#             }
+#             children.append(file_info)
+# 
+#         try:
+#             parent = (list(Path(root).parent.parts)[-1])
+#         except IndexError:
+#             parent = b''
+#         root_info = {
+#             'type': 'directory',
+#             # 'name': root,
+#             'parent': parent,
+#             'name': os.path.basename(root),
+#             'children': children,
+#         }
+#         res.append(root_info)
+#     pprint.pprint(res)
+#     return res
+
+def old_archive_walk(path):
     """Generates simple dicts with archive listing for the archive. """
-    print(path)
-    walk_iter = os.walk(path, topdown=True)
-    print(list(next(walk_iter)))
-    res = []
-    for root, dirs, files in walk_iter:
-        print("Root:")
-        print(root)
-        print("Dirs:")
-        print(dirs)
-        print("Files:")
-        print(files)
-        children = []
-        for d in dirs:
-            dir_info = {
-<<<<<<< Updated upstream
+
+    for thing in path.iterdir():
+        print(thing)
+
+        print(type(thing))
+        if thing.is_dir():
+            yield {
                 'type': 'directory',
-                'name': d,
-                'children': [],
-=======
-                'type' : 'directory',
-                'name' :  d,
-                'children' : [],
->>>>>>> Stashed changes
+                'name': thing.name,
+                'children': list(old_archive_walk(thing)),
             }
-            children.append(dir_info)
-        for f in files:
-            file_info = {
-<<<<<<< Updated upstream
+
+        else:
+            print(models.Blob.create_from_file(thing).pk)
+            yield {
                 'type': 'file',
-                'name': f,
-                'blob_pk': models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
+                'name': thing.name,
+                'blob_pk': models.Blob.create_from_file(thing).pk,
+                'path': str(thing),
             }
-            children.append(file_info)
-        root_info = {
-            'type': 'directory',
-            'name': '/'.join(list(Path(root).parts[3:])),
-            'children': children,
-=======
-                'type' : 'file',
-                'name' : f,
-                'blob_pk' : models.Blob.create_from_file(Path(os.path.join(root, f))).pk,
+ 
+#def archive_walk(path):
+#    d = {'name': os.path.basename(path)}
+#    print(d)
+#    if os.path.isdir(path):
+#        d['type'] = "directory"
+#        d['children'] = [archive_walk(os.path.join(path,x)) for x in os.listdir\
+#(path)]
+#    else:
+#        d['type'] = "file"
+#        d['blob_pk'] = models.Blob.create_from_file(path).pk
+#    return d
+
+def archive_walk(path):
+    for entry in os.scandir(path):
+        print(entry.path)
+        if entry.is_dir(follow_symlinks=False):
+            yield {
+                'type': 'directory',
+                'name': entry.name,
+                'children': list(archive_walk(entry.path)),
             }
-            children.append(file_info)
-        root_info = {
-            'type' : 'directory',
-            'name' : '/'.join(list(Path(root).parts[3:])),
-            'children' : children,
->>>>>>> Stashed changes
-        }
-        res.append(root_info)
-    print(res)
-    return res
+        else:
+            yield {
+                'type': 'file',
+                'name': entry.name,
+                # 'blob_pk': models.Blob.create_from_file(entry.path).pk,
+                'path': entry.path
+            }
+
+def create_blobs(dirlisting):
+    for entry in dirlisting:
+        if entry['type'] == 'file':
+            print(entry['path'])
+            path = Path(entry['path'])
+            entry['blob_pk'] = models.Blob.create_from_file(path).pk
+        else:
+            create_blobs(entry['children'])
+    

--- a/snoop/data/analyzers/archives.py
+++ b/snoop/data/analyzers/archives.py
@@ -187,6 +187,7 @@ def unarchive(blob):
         create_blobs(listing)
 
     check_recursion(listing, blob.pk)
+    print(listing)
 
     return listing
 
@@ -218,5 +219,6 @@ def create_blobs(dirlisting):
             print(entry['path'])
             path = Path(entry['path'])
             entry['blob_pk'] = models.Blob.create_from_file(path).pk
+            del entry['path']
         else:
             create_blobs(entry['children'])

--- a/snoop/data/collections.py
+++ b/snoop/data/collections.py
@@ -158,6 +158,16 @@ class Collection:
         """
         return self.name
 
+    @property
+    def blob_root(self):
+        """Returns a Path with the current collection blob dir."""
+        return Path(settings.SNOOP_BLOB_STORAGE) / self.name
+
+    @property
+    def tmp_dir(self):
+        """Returns a Path to the blobs temporary directory."""
+        return self.blob_root / 'tmp'
+
     def migrate(self):
         """Run `django migrate` on this collection's database."""
 
@@ -238,11 +248,11 @@ def create_roots():
     Also creates a root document entry for the input data, so we have something to export.
     """
 
-    from .models import blob_root, Directory
+    from .models import Directory
 
     for col in ALL.values():
         with transaction.atomic(using=col.db_alias), col.set_current():
-            root_path = blob_root()
+            root_path = current().blob_root
             # Avoid to run mkdir over a symlink.
             # This will still error out if there's a file at that location.
             if not root_path.is_symlink():

--- a/snoop/data/models.py
+++ b/snoop/data/models.py
@@ -19,20 +19,13 @@ from .magic import Magic
 from . import collections
 
 
-def blob_root():
-    """Returns a Path with the current collection blob dir.
-    """
-    col = collections.current()
-    return Path(settings.SNOOP_BLOB_STORAGE) / col.name
-
-
 def blob_repo_path(sha3_256):
     """Returns a Path pointing to the blob file for given hash.
 
     Args:
         sha3_256: hash used to compute the file path
     """
-    return blob_root() / sha3_256[:2] / sha3_256[2:4] / sha3_256[4:]
+    return collections.current().blob_root / sha3_256[:2] / sha3_256[2:4] / sha3_256[4:]
 
 
 def chunks(file, blocksize=65536):
@@ -175,7 +168,7 @@ class Blob(models.Model):
             BlobWriter: Use `.write(byte_string)` on the returned object until finished. The final result
                 can be found at `.blob` on the same object, after exiting this contextmanager's context.
         """
-        blob_tmp = blob_root() / 'tmp'
+        blob_tmp = collections.current().tmp_dir
         blob_tmp.mkdir(exist_ok=True, parents=True)
 
         fields = {}

--- a/testsuite/test_archives.py
+++ b/testsuite/test_archives.py
@@ -160,7 +160,9 @@ def test_unarchive_mbox(taskmanager, testdata_current):
         listing = json.load(f)
 
     assert len(listing) == 28
-    assert listing[0] == {
+    dir07 = [x for x in listing if x['name'] == '07'][0]
+    print(dir07)
+    assert dir07 == {
         'children': [
             {'blob_pk': '7779d128a2cd425eba06693b56e1fc7351c1d66c2ee78c96dd4bd5649307f636',
              'name': '0716d9708d321ffb6a00818614779e779925365c.eml',

--- a/testsuite/test_archives.py
+++ b/testsuite/test_archives.py
@@ -161,7 +161,6 @@ def test_unarchive_mbox(taskmanager, testdata_current):
 
     assert len(listing) == 28
     dir07 = [x for x in listing if x['name'] == '07'][0]
-    print(dir07)
     assert dir07 == {
         'children': [
             {'blob_pk': '7779d128a2cd425eba06693b56e1fc7351c1d66c2ee78c96dd4bd5649307f636',


### PR DESCRIPTION
closes CRJI/EIC#670

There is still an issue, where the temporary directories are included in the created path. 