### PR TITLE
Fix double queueing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -157,7 +157,7 @@ services:
   commands:
 
 - name: snoop-rabbitmq
-  image: rabbitmq:3.7.3
+  image: rabbitmq:3.8.5-management-alpine
   volumes:
   - name: rabbit-v
     path: /var/lib/rabbitmq
@@ -273,6 +273,7 @@ steps:
     SNOOP_DB: "postgresql://snoop:snoop@snoop-pg:5432/snoop"
     SNOOP_COLLECTIONS: '[{"name": "testdata", "process": true}]'
     SNOOP_AMQP_URL: "amqp://snoop-rabbitmq"
+    SNOOP_RABBITMQ_HTTP_URL: "snoop-rabbitmq:15672/"
     SNOOP_TIKA_URL: "http://snoop-tika:9998"
     SNOOP_THUMBNAIL_URL: "http://snoop-thumbnail:8000/"
     SNOOP_PDF_PREVIEW_URL: "http://snoop-pdf-preview:3000/"

--- a/snoop/data/tasks.py
+++ b/snoop/data/tasks.py
@@ -821,11 +821,16 @@ def get_rabbitmq_queue_length(q):
 
     from pyrabbit.api import Client
 
-    cl = Client(settings.SNOOP_RABBITMQ_HTTP_URL,
-                settings.SNOOP_RABBITMQ_HTTP_USERNAME,
-                settings.SNOOP_RABBITMQ_HTTP_PASSWORD)
-    q_depth = cl.get_queue_depth('/', q)
-    return q_depth
+    try:
+        cl = Client(settings.SNOOP_RABBITMQ_HTTP_URL,
+                    settings.SNOOP_RABBITMQ_HTTP_USERNAME,
+                    settings.SNOOP_RABBITMQ_HTTP_PASSWORD)
+        q_depth = cl.get_queue_depth('/', q)
+        return q_depth
+    except Exception as e:
+        logger.warning('cannot get rabbit queue length for queue %s: %s', q, str(e))
+        logger.warning('returning length 0 for unknown queue %s', q)
+        return 0
 
 
 def single_task_running(key):

--- a/snoop/defaultsettings.py
+++ b/snoop/defaultsettings.py
@@ -292,6 +292,16 @@ A single worker core running zero-length tasks gets at most around 40
 tasks/s, so to keep them all occupied for 5min: 12000
 """
 
+DISPATCH_MIN_QUEUE_SIZE = int(DISPATCH_QUEUE_LIMIT / 10)
+"""If the task count on the queue is less than this value (10%),
+and if we would queue at least another DISPATCH_QUEUE_LIMIT, then
+dispatch more tasks. This is used to reduce waiting between batches.
+"""
+
+
+DISPATCH_MAX_QUEUE_SIZE = int(DISPATCH_QUEUE_LIMIT * 4)
+"""Don't queue anything on a queue if its length is greater than this value."""
+
 SYNC_RETRY_LIMIT_DIRS = 100
 """ If there are no pending tasks, this is how many directories
 will be retried by sync every minute.


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/807

- adjusted dispatcher and task runner so it never queues more than some 40,000 tasks on a specific queue
- made adjustments to the dispatcher logic to lower proabability of double queueing

This does not remove the problem, since for outdated tasks we re-queue task types on separate dispatcher runs for each queue.